### PR TITLE
Let the allow vector define what aliases are applied

### DIFF
--- a/src/deck.ts
+++ b/src/deck.ts
@@ -76,7 +76,7 @@ export class Deck {
 	 * @returns
 	 */
 	public validate(allowVector: CardVector, options?: Partial<DeckSizes>): DeckError[] {
-		const deckVector = deckToVector(this.contents, this.index);
+		const deckVector = deckToVector(this.contents, this.index, allowVector);
 		return [...checkSizes(this.contents, options), ...checkLimits(deckVector, allowVector, this.index)];
 	}
 }

--- a/src/deck.ts
+++ b/src/deck.ts
@@ -62,14 +62,9 @@ export class Deck {
 		return (this.cachedSideText ||= generateText(this.contents.side, this.index));
 	}
 
-	private cachedVector?: CardVector;
-	private get vector(): CardVector {
-		return (this.cachedVector ||= deckToVector(this.contents, this.index));
-	}
-
 	private cachedThemes?: string[];
 	get themes(): string[] {
-		return (this.cachedThemes ||= classify(this.contents, this.vector, this.index));
+		return (this.cachedThemes ||= classify(this.contents, deckToVector(this.contents, this.index), this.index));
 	}
 
 	/**
@@ -81,6 +76,7 @@ export class Deck {
 	 * @returns
 	 */
 	public validate(allowVector: CardVector, options?: Partial<DeckSizes>): DeckError[] {
-		return [...checkSizes(this.contents, options), ...checkLimits(this.vector, allowVector, this.index)];
+		const deckVector = deckToVector(this.contents, this.index);
+		return [...checkSizes(this.contents, options), ...checkLimits(deckVector, allowVector, this.index)];
 	}
 }

--- a/src/vector.ts
+++ b/src/vector.ts
@@ -19,7 +19,9 @@ export type CardIndex = Map<number, ICard>;
 export type CardVector = Map<number, number>;
 
 /**
- * Aliases are treated as the same card.
+ * Only cards in this vector are considered for acceptance, and cards not in this
+ * vector are rejected. If the evaluation function decides to accept an alias and
+ * treat it as the same card, it should return a negative value.
  *
  * @param cards      Base card pool
  * @param evaluate   Evaluate the card and decide how many copies are allowed
@@ -28,22 +30,30 @@ export type CardVector = Map<number, number>;
 export function createAllowVector(cards: CardIndex, evaluate: (card: ICard) => number): CardVector {
 	const vector: CardVector = new Map();
 	for (const [password, card] of cards) {
-		if (card.alias === undefined) {
-			vector.set(password, evaluate(card));
+		const limit = evaluate(card);
+		if (limit != 0) {
+			vector.set(password, limit);
 		}
 	}
 	return vector;
 }
 
 /**
- * @param deck   The standard deck representation to vectorise
- * @param cards  Used to normalise aliases to the same card
- * @returns      Card vector where each component is the quantity of that card and aliases
+ * @param deck        The standard deck representation to vectorise
+ * @param cards       Used to normalise aliases to the same card
+ * @param allowVector If provided, used to decide whether to normalise an alias or leave it be
+ * @returns           Card vector where each component is the quantity of that card and aliases
  */
-export function deckToVector(deck: TypedDeck, cards: CardIndex): CardVector {
+export function deckToVector(deck: TypedDeck, cards: CardIndex, allowVector?: CardVector): CardVector {
 	const vector: CardVector = new Map();
 	const deckReducer = (password: number) => {
-		const index = cards.get(password)?.alias || password;
+		const index = (() => {
+			if (!allowVector || (allowVector.get(password) || 0) < 0) {
+				return cards.get(password)?.alias || password;
+			} else {
+				return password;
+			}
+		})();
 		vector.set(index, 1 + (vector.get(index) || 0));
 	};
 	deck.main.forEach(deckReducer);

--- a/test/test.ts
+++ b/test/test.ts
@@ -93,14 +93,38 @@ before(async () => {
 			cardIndex.set(Number(password), await convertCard(cardList[password]));
 		}
 	}
-	tcgAllowVector = createAllowVector(cardIndex, card =>
-		isNaN(card.limitTCG) || card.isPrerelease ? 0 : card.limitTCG
-	);
-	ocgAllowVector = createAllowVector(cardIndex, card =>
-		isNaN(card.limitOCG) || card.isPrerelease ? 0 : card.limitOCG
-	);
-	prereleaseWithTcg = createAllowVector(cardIndex, card => (isNaN(card.limitTCG) ? 3 : card.limitTCG));
-	prereleaseWithOcg = createAllowVector(cardIndex, card => (isNaN(card.limitOCG) ? 3 : card.limitOCG));
+	tcgAllowVector = createAllowVector(cardIndex, card => {
+		if (isNaN(card.limitTCG) || card.isPrerelease) {
+			return 0;
+		} else if (card.alias) {
+			return -1;
+		} else {
+			return card.limitTCG;
+		}
+	});
+	ocgAllowVector = createAllowVector(cardIndex, card => {
+		if (isNaN(card.limitOCG) || card.isPrerelease) {
+			return 0;
+		} else if (card.alias) {
+			return -1;
+		} else {
+			return card.limitOCG;
+		}
+	});
+	prereleaseWithTcg = createAllowVector(cardIndex, card => {
+		if (card.alias) {
+			return -1;
+		} else {
+			return isNaN(card.limitTCG) ? 3 : card.limitTCG;
+		}
+	});
+	prereleaseWithOcg = createAllowVector(cardIndex, card => {
+		if (card.alias) {
+			return -1;
+		} else {
+			return isNaN(card.limitOCG) ? 3 : card.limitOCG;
+		}
+	});
 });
 
 describe("Construction", function () {


### PR DESCRIPTION
The vector contains all cards that will be considered. Cards not in it are automatically illegal. To allow an alias and treat it as the main, set a negative value for it. If an alias is set to a positive value then it's treated as a separate card. Caveat: if the main is forbidden and some aliases are to be allowed, they cannot be treated as separate cards.